### PR TITLE
Fix for frontend card not always loading

### DIFF
--- a/custom_components/neerslag/load_frontend.py
+++ b/custom_components/neerslag/load_frontend.py
@@ -11,12 +11,48 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def setup_view(hass: HomeAssistant):
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    path_to_file = "{}/home-assistant-neerslag-card/neerslag-card.js".format(dir_path)
-    should_cache = False
-
     timestamp = str(time.time())
     frontend_script_url_with_parameter = FRONTEND_SCRIPT_URL+"?cache="+timestamp
+
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                FRONTEND_SCRIPT_URL,
+                hass.config.path("custom_components/neerslag/home-assistant-neerslag-card/neerslag-card.js"),
+                True
+            )
+        ]
+    )
     add_extra_js_url(hass, frontend_script_url_with_parameter , es5=False)
 
-    await hass.http.async_register_static_paths([StaticPathConfig(FRONTEND_SCRIPT_URL, str(path_to_file), should_cache)])
+    # Check if Neerslag Card is loaded in frontend, if not: add it again
+    resources = hass.data["lovelace"]["resources"]
+    if resources:
+        if not resources.loaded:
+            await resources.async_load()
+            resources.loaded = True
+
+        frontend_added = False
+        for r in resources.async_items():
+            if r["url"].startswith(FRONTEND_SCRIPT_URL):
+                frontend_added = True
+                continue
+
+        if not frontend_added:
+            if getattr(resources, "async_create_item", None):
+                await resources.async_create_item(
+                    {
+                        "res_type": "module",
+                        "url": FRONTEND_SCRIPT_URL + "?automatically-added" + "&cache=" + timestamp,
+                    }
+                )
+            elif getattr(resources, "data", None) and getattr(
+                resources.data, "append", None
+            ):
+                resources.data.append(
+                    {
+                        "type": "module",
+                        "url": FRONTEND_SCRIPT_URL + "?automatically-added" + "&cache=" + timestamp,
+
+                    }
+                )


### PR DESCRIPTION
I kept having the issue of the card not loading in the frontend, as described in #53.
It seems that on some devices the script is not getting added to lovelace at all.

I had a look at the approach in the browser_mod addon and they implemented a fix for this specific issue, so I ported it to this addon. This fixes the issue for me.