### PR TITLE
Remove via_device

### DIFF
--- a/custom_components/neerslag/sensor.py
+++ b/custom_components/neerslag/sensor.py
@@ -157,7 +157,6 @@ class mijnBasis(Entity):
             "manufacturer": "aex351",
             "model": "All-in-one package",
             "sw_version": "",
-            "via_device": ("neerslag", "abcd"),
         }
 
     @property


### PR DESCRIPTION
Removed via_device from device_info as it's not needed and giving errors.
Fixes #69 and #70 